### PR TITLE
[FIXES #1] Fix forksoverknives.com

### DIFF
--- a/src/css/recipe_filter.css
+++ b/src/css/recipe_filter.css
@@ -1,16 +1,18 @@
-#_rf_highlight {
-	position: absolute !important;
-	top: 0 !important;
-	left: 50% !important;
-	transform: translate(-50%, 0) !important;
-	margin: 20px !important;
-	padding: 10px !important;
-	background: white !important;
-	z-index: 999999999 !important;
-	box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 0px 9999999px !important;
-	max-width: 700px !important;
-	min-width: 340px !important;
-	display: none;
+#_rf_highlight_container {
+    position: absolute !important;
+    top: 0 !important;
+    z-index: 999999999 !important;
+    margin: 20px !important;
+    padding: 10px !important;
+    background: white !important;
+    box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 0px 9999999px !important;
+    max-width: 700px !important;
+    min-width: 340px !important;
+    transform: translate(50%, 0) !important;
+}
+
+div[id^='_rf_highlight'] {
+	display: block;
 }
 
 #_rf_header {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,43 +1,57 @@
-recipe_selectors = [
-	'.recipe-callout',
-	'.tasty-recipes',
-	'.easyrecipe',
-	'.innerrecipe',
-	'.recipe-summary.wide', // thepioneerwoman.com
-	'.wprm-recipe-container',
-	'.recipe-content',
-	'div[itemtype="http://schema.org/Recipe"]',
-	'div[itemtype="https://schema.org/Recipe"]',
+recipe_selector_groups = [
+	['.recipe-callout'],
+	['.tasty-recipes'],
+	['.main-header', '.ingredients', '.article-content'], // forksoverknives.com
+	['.recipe-summary.wide'], // thepioneerwoman.com
+	['.easyrecipe'],
+	['.innerrecipe'],
+	['.wprm-recipe-container'],
+	['.recipe-content'],
+	['div[itemtype="http://schema.org/Recipe"]'],
+	['div[itemtype="https://schema.org/Recipe"]'],
 ]
 
 
-function hidePopup(){
-	$('#_rf_highlight').fadeOut();
+function hidePopup() {
+    $('#_rf_highlight_container').fadeOut();
 }
 
 function showPopup(){
-	recipe_selectors.every(function(s){
-		$r = $(s);
-		if ($r.length === 1){
-			// clone the matched element and add some control buttons
-			$r.clone().attr('id', '_rf_highlight').prependTo('body').append(`
-				<div id="_rf_header">
-					<button id="_rf_closebtn" class="_rfbtn">close recipe</button>
-					RecipeFilter
-					<button id="_rf_disablebtn" class="_rfbtn">disable on this site</button>
-				</div>
-			`).fadeIn(500);
+	recipe_selector_groups.every(function(recipe_selector_group){
+        var results = recipe_selector_group
+                    .map(selector => $(selector))
+                    .filter($result => $result.length === 1);
+        if (results.length === recipe_selector_group.length) {
+            // prepend the container popup div to <body>
+            $('body').prepend(`
+                <div id="_rf_highlight_container"></div>
+            `);
 
-			// handle the two new buttons we attached to the popup
-			$('#_rf_closebtn').click(hidePopup);
-			$('#_rf_disablebtn').click(function(b){
-				chrome.storage.sync.set({[document.location.hostname]: true}, hidePopup);
-			});
+            // clone the matched elements into the popup (while maintaining the selector ordering)
+            const last_element_id = results.length - 1;
+            for (var i = last_element_id; i >= 0; i--) {
+                results[i].clone().attr('id', '_rf_highlight' + i).prependTo('div#_rf_highlight_container');
+            }
 
-			// add an event listener for clicking outside the recipe to close it
+            // add some control buttons to the popup
+            $('#_rf_highlight' + last_element_id).append(`
+                <div id="_rf_header">
+                    <button id="_rf_closebtn" class="_rfbtn">close recipe</button>
+                    RecipeFilter
+                    <button id="_rf_disablebtn" class="_rfbtn">disable on this site</button>
+                </div>
+            `).fadeIn(500);
+
+            // register click handlers for the control buttons we attached to the popup
+            $('#_rf_closebtn').click(hidePopup);
+            $('#_rf_disablebtn').click(function(b){
+                chrome.storage.sync.set({[document.location.hostname]: true}, hidePopup);
+            });
+
+			// add an event listener for clicking outside the popup to close it
 			$(document).mouseup(function(e) {
-				var container = $('#_rf_highlight');
-				if (!container.is(e.target) && container.has(e.target).length === 0) 
+				var container = $('#_rf_highlight_container');
+				if (!container.is(e.target) && container.has(e.target).length === 0)
 				{
 				    hidePopup();
 				    $(document).unbind('mouseup');
@@ -46,7 +60,8 @@ function showPopup(){
 
 			// scroll to top in case they hit refresh while lower in page
 			$(window).scrollTop(0);
-			// it worked, stop iterating through recipe_selectors
+
+			// it worked, stop iterating through recipe_selector_groups
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Use an array of selectors to see if a page has a hit. Every selector in the array must match. If the array matches then every element will be added to the popup in the order it is found. There isn't much of a use case for this outside of forksoverknives.com but there probably will be in the future. This allows for the popup to be composed of many element from the source page.

https://www.gimmesomeoven.com/instant-pot-steamed-artichokes/
![popup1](https://user-images.githubusercontent.com/5605580/37321577-2f8287ee-2636-11e8-9fb7-0897e20e24b0.gif)

https://www.forksoverknives.com/recipes/rainbow-pasta-salad/
![popup2](https://user-images.githubusercontent.com/5605580/37321582-342a056a-2636-11e8-8a6e-f793f5b4c023.gif)
