### PR TITLE
Add 'simple-recipe-pro' class

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -6,6 +6,7 @@ recipe_selectors = [
 	'.recipe-summary.wide', // thepioneerwoman.com
 	'.wprm-recipe-container',
 	'.recipe-content',
+	'.simple-recipe-pro',
 	'div[itemtype="http://schema.org/Recipe"]',
 	'div[itemtype="https://schema.org/Recipe"]',
 ]


### PR DESCRIPTION
Adds support for recipes in a `simple-recipe-pro` DIV.

Example page: https://www.fifteenspatulas.com/crispy-baked-chicken-wings-yup-no-deep-fryer-in-sight/