### PR TITLE
Don't close recipe overlay on consent approval

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -56,7 +56,7 @@ function showPopup(){
 
 			// add an event listener for clicking outside the recipe to close it
 			let mouseUpHide = function(e) {
-				if (e.target !== clone && !clone.contains(e.target)) 
+				if (e.target !== clone && !clone.contains(e.target) && event.target.type !== 'submit')
 				{
 				    hidePopup();
 				    document.removeEventListener('mouseup', mouseUpHide);


### PR DESCRIPTION
Some websites overlay the entire page with a consent dialog (example: https://www.simplyrecipes.com/recipes/tomatillo_salsa_verde/) that opens on top of the recipe overlay. Closing this dialog by accepting/declining causes the recipe overlay to close as well which effectively makes it unusable in those pages.

![image](https://user-images.githubusercontent.com/6243438/80366026-d8a76400-8888-11ea-829d-5c07df9fcb9b.png)


I'm not sure if there are any side effects to this change, but from my short testing it seemed to be working as expected.