### PR TITLE
add extension context option to reshow popup without needing to refre…

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,0 +1,11 @@
+chrome.contextMenus.create({
+ id: "reshow-popup",
+ title: "Reshow Popup",
+ contexts:["browser_action"],
+ onclick: function () {
+   //Send message to active tab's content script
+   chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
+     chrome.tabs.sendMessage(tabs[0].id, {action: "reshow_popup"}, function(response) {});
+   });
+ }
+});

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -5,7 +5,7 @@ chrome.contextMenus.create({
  onclick: function () {
    //Send message to active tab's content script
    chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-     chrome.tabs.sendMessage(tabs[0].id, {action: "reshow_popup"}, function(response) {});
+     chrome.tabs.sendMessage(tabs[0].id, {action: "reshow_popup"});
    });
  }
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -34,6 +34,18 @@ function hidePopup(){
 	highlight.style.opacity = 0;
 }
 
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse) {
+    if (request.action == "reshow_popup")
+			reshowPopup();
+      sendResponse({farewell: "goodbye"});
+  });
+
+function reshowPopup() {
+	let existingPopup = document.getElementById('_rf_highlight');
+	existingPopup.style.opacity = 1;
+}
+
 function showPopup(){
 	recipe_selectors.every(function(s){
 		let original = document.querySelector(s);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,10 +35,10 @@ function hidePopup(){
 }
 
 chrome.runtime.onMessage.addListener(
-  function(request, sender, sendResponse) {
+  function(request) {
     if (request.action == "reshow_popup")
 			reshowPopup();
-      sendResponse({farewell: "goodbye"});
+      //sendResponse({farewell: "goodbye"});
   });
 
 function reshowPopup() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,12 +8,14 @@
           "128": "img/icon-128.png"
   },
   "permissions": [
+    "contextMenus",
     "storage"
   ],
   "options_page": "html/options.html",
   "browser_action": {
     "default_title": "Recipe Filter",
     "default_icon": "img/icon-128.png"
+
   },
   "content_scripts": [
     {
@@ -23,5 +25,8 @@
       "css": ["css/recipe_filter.css"],
       "js": ["js/main.js"]
     }
-  ]
+  ],
+  "background": {
+    "scripts": ["js/background.js"]
+  }
 }


### PR DESCRIPTION
resolves #17 
Add a button to the extension's context menu to re-show the popup without having to refresh the recipe page.
* Update manifest to include contextMenu permissions and a background script
* Add background script file that adds the option to the extension's right click menu
* Update content script to listen for message passed by background script for when the context menu item gets clicked. It will make the opacity 1 for the popup to re-show it