### PR TITLE
Fix issue where modal was clickable after closed

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -32,6 +32,10 @@ function hidePopup(){
 	let highlight = document.getElementById('_rf_highlight');
 	highlight.style.transition = 'opacity 400ms';
 	highlight.style.opacity = 0;
+
+	setTimeout(function() {
+		highlight.style.display = 'none';
+	}, 400);
 }
 
 function showPopup(){

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -34,7 +34,7 @@ function hidePopup(){
 	highlight.style.opacity = 0;
 
 	setTimeout(function() {
-		highlight.style.display = 'none';
+		highlight.parentNode.removeChild(highlight);
 	}, 400);
 }
 


### PR DESCRIPTION
Currently, when the recipe modal is closed / hidden, the user can still interact with it. It's visually hidden, but can still be clicked as it could when visible, making clicking things underneath impossible.

This sets `display: none` after the animation is over.