### PR TITLE
Addresses issue #34: make the dialog close on pressing 'escape' key

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -69,6 +69,15 @@ function showPopup(){
 			};
 			document.addEventListener('mouseup', mouseUpHide);
 
+			// add an event listener for closing the dialog by hitting 'escape'
+			const escapeUpHide = function (e) {
+				if (e.key === 'Escape') {
+					hidePopup()
+					document.removeEventListener('keyup', escapeUpHide)
+				}
+			}
+			document.addEventListener('keyup', escapeUpHide)
+
 			window.setTimeout(() => {
 				// fade in
 				clone.style.opacity = 1;


### PR DESCRIPTION
Issue #34

- Added escapeUpHide that executes hidePopup if we get a keycode matching 'Escape'
- Added it to a 'keyup' listener