### PR TITLE
chore: restructure the manifest to V3

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -8,13 +8,18 @@ chrome.storage.sync.get(null, function(data){
 	let rowMarkup = '';
 	let selectors = [];
 
-	for (site in data) {
+	for (let site in data) {
 		rowMarkup += `<tr>
 			<td id="${site}" class="trash-cell" style="cursor:pointer;">&#9447;</td>
 			<td>${site}</td>
 		</tr>`;
 		selectors.push(`[id="${site}"]`);
 	}
+
+	if (selectors.length === 0) {
+		return;
+	}
+
 	document.querySelector('#blacklist tbody').innerHTML = rowMarkup;
 	document.querySelectorAll(selectors.join(',')).forEach((td) => {
 		td.addEventListener('click', remove);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,17 +1,17 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Recipe Filter",
-  "short_name": "Recipe Filter",
+  "short_name": "RecipeFilter",
   "version": "0.3",
   "description": "Recipe Filter shows recipes found anywhere on the web in a handy popup.",
   "icons": {
-          "128": "img/icon-128.png"
+    "128": "img/icon-128.png"
   },
   "permissions": [
     "storage"
   ],
   "options_page": "html/options.html",
-  "browser_action": {
+  "action": {
     "default_title": "Recipe Filter",
     "default_icon": "img/icon-128.png"
   },
@@ -23,5 +23,6 @@
       "css": ["css/recipe_filter.css"],
       "js": ["js/main.js"]
     }
-  ]
+  ],
+  "content_security_policy": {}
 }


### PR DESCRIPTION
There wasn't any big changes necessary, mostly renaming keys. Google's [conversion tool](https://developer.chrome.com/blog/extension-manifest-converter) did all the work.

Resolves #38 